### PR TITLE
Fix #2: A missing template index file no longer raises a breaking error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 
 .DS_Store
+.idea/*

--- a/.idea/lpm.git.iml
+++ b/.idea/lpm.git.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 2.7.6 virtualenv at ~/.virtualenvs/lpm" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.6 virtualenv at ~/.virtualenvs/lpm" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/lpm.git.iml" filepath="$PROJECT_DIR$/.idea/lpm.git.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lpm/__main__.py
+++ b/lpm/__main__.py
@@ -12,11 +12,12 @@ import sys
 import io
 import yaml
 import argparse
+import logging
 
-from py_lpm.config import find_config_files, DEFAULT_SETTINGS
-from py_lpm.config.LPMConfigParser import LPMConfigParser
-from py_lpm.functions import make_template as make_template_func
-from py_lpm.functions import init_project as init_project_func
+from lpm.config import find_config_files, DEFAULT_SETTINGS
+from lpm.config.LPMConfigParser import LPMConfigParser
+from lpm.functions import make_template as make_template_func
+from lpm.functions import init_project as init_project_func
 
 
 def make_args(args, config_file):
@@ -49,7 +50,10 @@ def main():
 
     full_path = "{}index.yaml".format(template_path)
 
-    templates = yaml.load(open(os.path.expanduser(full_path), 'r+'))
+    try:
+        templates = yaml.load(open(os.path.expanduser(full_path), 'r+'))
+    except IOError as e:
+        print "No template index found in {}.  Templates will be unavailable.".format(full_path)
 
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help="Where does this show up?")

--- a/lpm/config/LPMConfigParser.py
+++ b/lpm/config/LPMConfigParser.py
@@ -1,6 +1,11 @@
 import ConfigParser
 
+
 class LPMConfigParser(ConfigParser.SafeConfigParser):
+    """ Defines the custom extension from `ConfigParser.SafeConfigParser` used by `lpm`
+
+    TODO: Export the current configuration as a YAML object
+    """
 
     def find_config_parser(self):
         pass

--- a/lpm/config/__init__.py
+++ b/lpm/config/__init__.py
@@ -6,7 +6,7 @@ import os, io
 DEFAULT_SETTINGS = """
 [General]
 project_root_path=/opt/projects.lpm/
-template_path=/usr/local/lpm/templates/
+template_path=~/.lpm/templates/
 """
 
 DEFAULT_SEARCH_PATH =  ["{}/".format(os.getcwd()),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 gitpython
 pyaml
 virtualenv
-gitpython
 


### PR DESCRIPTION
*  Fixed a breaking error where a missing `templates/index.yaml` file caused the application to fail.  It now reports that templates will be unavailable until the index is created, but otherwise continues on.
*  Tried removing PyCharm project files from the repository.

Closes Issue #2 