### PR TITLE
Lpm 4: Install default config files from the CLI

### DIFF
--- a/lpm/__main__.py
+++ b/lpm/__main__.py
@@ -18,6 +18,7 @@ from lpm.config import find_config_files, DEFAULT_SETTINGS
 from lpm.config.LPMConfigParser import LPMConfigParser
 from lpm.functions import make_template as make_template_func
 from lpm.functions import init_project as init_project_func
+from lpm.functions import settings_cmd as settings_func
 
 
 def make_args(args, config_file):
@@ -80,6 +81,11 @@ def main():
     init_project.add_argument('-t', '--template', type=str, help='The name of the template to use')
     init_project.add_argument('-o', '--output', type=str, help='Project root directory',
                               default=os.path.expanduser(config_file.get('General', 'project_root_path')))
+
+    settings_cmd = subparsers.add_parser('settings', help='list or edit application settings')
+    settings_cmd.set_defaults(func=settings_func)
+
+    settings_cmd.add_argument('-e', '--export', type=bool, default=False, help='exports the settings')
 
     args = parser.parse_args()
     args.func(**make_args(args, config_file))

--- a/lpm/config/__init__.py
+++ b/lpm/config/__init__.py
@@ -3,11 +3,7 @@
 import LPMConfigParser
 import os, io
 
-DEFAULT_SETTINGS = """
-[General]
-project_root_path=/opt/projects.lpm/
-template_path=~/.lpm/templates/
-"""
+DEFAULT_SETTINGS = open("{}/{}".format(os.getcwd(), '../templates/.lpm.conf'), 'r+').read()
 
 DEFAULT_SEARCH_PATH =  ["{}/".format(os.getcwd()),
                         "{}/".format(os.path.expanduser("~")),
@@ -20,7 +16,7 @@ def find_config_files(filename='.lpm.conf', search_paths = DEFAULT_SEARCH_PATH):
     for path in search_paths:
         full_file_reference = "{}{}".format(path, filename)
         if os.path.isfile(full_file_reference):
-           files_found.append(full_file_reference)
+            files_found.append(full_file_reference)
 
     return files_found
 

--- a/lpm/functions.py
+++ b/lpm/functions.py
@@ -116,4 +116,13 @@ def init_project(name, template, output, config_file):
         subprocess.call(['python', bootstrap_path, project_directory])
 
 
+def settings_cmd(export, config_file):
+    """ Defines the operations of the `settings` command
 
+    TODO: write the export behavior to copy the template files to their default directories
+
+    Usage: `python -m lpm settings --export=True`
+    """
+
+    if export:
+        pass    # os.copy('../templates/.lpm.conf', '~/.lpm.conf')

--- a/templates/.lpm.conf
+++ b/templates/.lpm.conf
@@ -1,0 +1,3 @@
+[General]
+project_root_path=/opt/projects.lpm/
+template_path=~/.lpm/templates/


### PR DESCRIPTION
*  Updated the default `ConfigParser` settings string to come from the template file in `templates/.lpm.conf`.
*  Stubbed the `settings` command in `lpm.functions.setting_cmd`

# Todo
- [ ] Add a command to create default settings files #4
- [ ] Add: function to copy configuration templates to default location #5 